### PR TITLE
When select has no items, dont crash

### DIFF
--- a/src/components/select.js
+++ b/src/components/select.js
@@ -64,6 +64,9 @@ class Select extends Component {
 
   handleKeyPress(ch, key) {
     const {cursor, options} = this.state;
+    if (!options || options.length <= 0) {
+      return;
+    }
 
     switch (key.name) {
       case 'up': {

--- a/test/components/select.test.js
+++ b/test/components/select.test.js
@@ -27,6 +27,23 @@ test('calls onChange when moving down the options', t => {
   t.false(onSelect.called);
 });
 
+test('doesnt crash when theres no options', t => {
+  const setRef = spy();
+  const onChange = spy();
+  const onSelect = spy();
+
+  renderToString(
+    <Select ref={setRef} onChange={onChange} onSelect={onSelect}/>
+  );
+
+  const ref = setRef.firstCall.args[0];
+  ref.handleKeyPress('', {name: 'down'});
+  ref.handleKeyPress('', {name: 'return'});
+
+  t.false(onSelect.called);
+  t.false(onChange.called);
+});
+
 test('calls onChange when moving up the options', t => {
   const setRef = spy();
   const onChange = spy();


### PR DESCRIPTION
At the moment, if you have a `<Select>` element with no children and the user pressed `enter`, `down` or any of the other key commands, then `ink-select` will throw a reference error. 

This can be unwanted behavior when you're dynamically generating select options :( 

This pull request does the following:
* Leave the `handleKeyPress` early if there's no options, so we don't crash. 
* Adds a test to verify this behavior. 

Thanks so much for the library! I hope this helps! :heart: